### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 ; vi:syntax=ini
-; See https://coverage.readthedocs.org/en/coverage-4.0.3/config.html
+; See https://coverage.readthedocs.io/en/coverage-4.0.3/config.html
 
 [run]
 data_file = .coverage

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -50,7 +50,7 @@ Next Release
 - First real release.
 - Feature/ Unit test suite, very high coverage.
 - Feature/ ``redislite`` integration.
-- Feature/ Documentation.  https://cache-requests.readthedocs.org.
+- Feature/ Documentation.  https://cache-requests.readthedocs.io.
 - Feature/ Exposed the beefed up ``Memoize`` decorator.
 - Feature/ Upgraded compatibility to:
     - PY26

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ cache_requests
     :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/cache_requests/badge/?version=develop
-    :target: https://cache_requests.readthedocs.org/en/develop/?badge=develop
+    :target: https://cache_requests.readthedocs.io/en/develop/?badge=develop
     :alt: Documentation Status
 
 ------------
@@ -67,7 +67,7 @@ cache_requests
 Features
 --------
 
-- Documentation: https://cache_requests.readthedocs.org
+- Documentation: https://cache_requests.readthedocs.io
 - Open Source: https://github.com/bionikspoon/cache_requests
 - Python version agnostic: tested against Python 2.7, 3.3, 3.4, 3.5 and Pypy
 - MIT license

--- a/docs/source/_partial/readme_features.rst
+++ b/docs/source/_partial/readme_features.rst
@@ -1,7 +1,7 @@
 Features
 --------
 
-- Documentation: https://cache_requests.readthedocs.org
+- Documentation: https://cache_requests.readthedocs.io
 - Open Source: https://github.com/bionikspoon/cache_requests
 - Python version agnostic: tested against Python 2.7, 3.3, 3.4, 3.5 and Pypy
 - MIT license

--- a/docs/source/_partial/readme_title.rst
+++ b/docs/source/_partial/readme_title.rst
@@ -19,7 +19,7 @@ cache_requests
     :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/cache_requests/badge/?version=develop
-    :target: https://cache_requests.readthedocs.org/en/develop/?badge=develop
+    :target: https://cache_requests.readthedocs.io/en/develop/?badge=develop
     :alt: Documentation Status
 
 ------------

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-"""The full documentation is at https://cache_requests.readthedocs.org."""
+"""The full documentation is at https://cache_requests.readthedocs.io."""
 
 try:
     from setuptools import setup


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
